### PR TITLE
Fix for multi-kernel aggregation

### DIFF
--- a/sst-gpgpusim/src/gpgpu-sim/shader.cc
+++ b/sst-gpgpusim/src/gpgpu-sim/shader.cc
@@ -593,6 +593,12 @@ void shader_core_stats::print( FILE* fout ) const
            gpu_stall_shd_mem_breakdown[L_MEM_LD][DATA_PORT_STALL] + 
            gpu_stall_shd_mem_breakdown[L_MEM_ST][DATA_PORT_STALL]    
            ); // data port stall at data cache 
+   fprintf(fout, "gpgpu_stall_shd_mem[gl_mem][ICNT_RC_FAIL] = %d\n",
+           gpu_stall_shd_mem_breakdown[G_MEM_LD][ICNT_RC_FAIL] +
+           gpu_stall_shd_mem_breakdown[G_MEM_ST][ICNT_RC_FAIL] +
+           gpu_stall_shd_mem_breakdown[L_MEM_LD][ICNT_RC_FAIL] +
+           gpu_stall_shd_mem_breakdown[L_MEM_ST][ICNT_RC_FAIL]
+           );
    //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][mshr_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_LD][MSHR_RC_FAIL]);
    //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_LD][ICNT_RC_FAIL]);
    //fprintf(fout, "gpgpu_stall_shd_mem[g_mem_ld][wb_icnt_rc] = %d\n", gpu_stall_shd_mem_breakdown[G_MEM_LD][WB_ICNT_RC_FAIL]);

--- a/sst-gpgpusim/src/gpgpusim_entrypoint.cc
+++ b/sst-gpgpusim/src/gpgpusim_entrypoint.cc
@@ -194,9 +194,6 @@ bool SST_Cycle()
 
 	if(g_stream_manager()->operation(&sst_sim_cycles) && !g_the_gpu()->active()) {
 		if(sst_sim_cycles) {
-			g_the_gpu()->print_stats();
-			g_the_gpu()->update_stats();
-			print_simulation_time();
 			sst_sim_cycles = false;
 		}
 		return false;
@@ -225,6 +222,12 @@ bool SST_Cycle()
 			GPGPUsim_ctx_ptr()->g_sim_active = false;
 			GPGPUsim_ctx_ptr()->break_limit = true;
 		}
+	}
+
+	if(!g_the_gpu()->active()){
+		g_the_gpu()->print_stats();
+		g_the_gpu()->update_stats();
+		print_simulation_time();
 	}
 
     if(GPGPUsim_ctx_ptr()->break_limit) {


### PR DESCRIPTION
This fixes multi-kernel aggregation (https://github.com/sstsimulator/sst-gpgpusim/issues/10) in the SST model that could happen if the stream queue is never empty.

